### PR TITLE
Glue updates

### DIFF
--- a/components/aws/glue-job/iam.tf
+++ b/components/aws/glue-job/iam.tf
@@ -2,7 +2,6 @@
 
 resource "aws_iam_role" "glue_job_role" {
   name = "${var.name_prefix}GlueJobRole"
-
   tags = var.resource_tags
 
   assume_role_policy = <<EOF
@@ -21,7 +20,6 @@ resource "aws_iam_role" "glue_job_role" {
   ]
 }
 EOF
-
 }
 
 resource "aws_iam_policy" "glue_job_policy" {
@@ -40,7 +38,7 @@ resource "aws_iam_policy" "glue_job_policy" {
                 "s3:ListBucket"
             ],
             "Resource": [
-                "arn:aws:s3:::${var.s3_script_bucket_name}",
+                "arn:aws:s3:::${local.s3_script_bucket_name}",
                 "arn:aws:s3:::${var.s3_source_bucket_name}",
                 "arn:aws:s3:::${var.s3_destination_bucket_name}"
             ]
@@ -50,7 +48,7 @@ resource "aws_iam_policy" "glue_job_policy" {
             "Effect": "Allow",
             "Action": "s3:*Object",
             "Resource": [
-                "arn:aws:s3:::${var.s3_script_bucket_name}/*",
+                "arn:aws:s3:::${local.s3_script_bucket_name}/*",
                 "arn:aws:s3:::${var.s3_source_bucket_name}/*",
                 "arn:aws:s3:::${var.s3_destination_bucket_name}/*"
             ]
@@ -59,7 +57,6 @@ resource "aws_iam_policy" "glue_job_policy" {
 }
 EOF
 }
-
 
 resource "aws_iam_role_policy_attachment" "glue_job_policy_attachment" {
   role       = aws_iam_role.glue_job_role.name

--- a/components/aws/glue-job/main.tf
+++ b/components/aws/glue-job/main.tf
@@ -1,6 +1,18 @@
 /*
 * Glue is AWS's fully managed extract, transform, and load (ETL) service. A Glue job can be used job to run ETL Python scripts.
+*
+*
 */
+
+locals {
+  # Reusable TF Snippet to parse S3 path into bucket+key: https://gist.github.com/aaronsteers/19eb4d6cba926327f8b25089cb79259b
+  s3_script_bucket_name = split("/", split("//", var.s3_script_path)[1])[0]
+  s3_script_key = join("/", slice(
+    split("/", split("//", var.s3_script_path)[1]),
+    1,
+    length(split("/", split("//", var.s3_script_path)[1]))
+  ))
+}
 
 resource "aws_glue_job" "glue_job" {
   name         = "${var.name_prefix}data-transformation"
@@ -10,8 +22,8 @@ resource "aws_glue_job" "glue_job" {
   max_capacity = 1
 
   command {
-    script_location = "s3://${var.s3_script_bucket_name}/${var.script_path}"
-    name            = var.job_type
-    python_version  = 3
+    script_location = var.s3_script_path
+    name            = var.use_spark ? "pyspark" : "python"
+    python_version  = 3 # Major version only. Allowed values are: 2 or 3
   }
 }

--- a/components/aws/glue-job/variables.tf
+++ b/components/aws/glue-job/variables.tf
@@ -24,27 +24,43 @@ variable "resource_tags" {
 ### Custom variables for this module ###
 ########################################
 
-variable "s3_script_bucket_name" {
-  description = "S3 script bucket for Glue transformation job."
+variable "s3_script_path" {
+  description = <<EOF
+Full S3 path to the python Glue script. If `local_script_path` is also specified, the local
+file will automatically be uploaded to the S3 path, replacing the existing file if
+applicable.
+EOF
   type        = string
+  default     = null
 }
 
 variable "s3_source_bucket_name" {
-  description = "S3 source bucket for Glue transformation job."
+  description = <<EOF
+S3 source bucket for Glue transformation job. The glue job will automatically be granted
+access to read and write from this bucket.
+EOF
   type        = string
 }
 
 variable "s3_destination_bucket_name" {
-  description = "S3 destination bucket for Glue transformation job."
+  description = <<EOF
+S3 destination bucket for Glue transformation job. The glue job will automatically be
+granted access to read and write from this bucket.
+EOF
   type        = string
 }
 
-variable "script_path" {
-  description = "Path to Glue script."
+variable "local_script_path" {
+  description = <<EOF
+Optional. Local path to the python Glue script. If this is not provided, the script file
+will be assumed to already exist at the location specified in `s3_script_path`.
+EOF
   type        = string
+  default     = null
 }
 
-variable "job_type" {
-  description = "Type of Glue job (Spark or Python Shell)."
-  type        = string
+variable "use_spark" {
+  description = "True to use 'pyspark' engine, otherwise 'python'."
+  type        = bool
+  default     = true
 }


### PR DESCRIPTION
Hi, Jack. We can wait on this until after ml-ops merges to master. 

This PR starts the work of refactoring and planning for generic Spark- and python-based transforms.

So far, the significant changes are just:
1. We take a full s3 path in `s3_script_path` and we parse it into bucket + key dynamically.
2. We just take a `use_spark` boolean (default=True) to decide which framework to use (Spark Python or classic Python).
