### PR TITLE
Add with_spark flag to worker vars for Glue job

### DIFF
--- a/components/aws/glue-job/main.tf
+++ b/components/aws/glue-job/main.tf
@@ -9,8 +9,8 @@ resource "aws_glue_job" "glue_job" {
   glue_version = "1.0"
   max_capacity = var.with_spark ? null : 1
 
-  worker_type       = "Standard"
-  number_of_workers = var.num_workers
+  worker_type       = var.with_spark ? "Standard" : null
+  number_of_workers = var.with_spark ? var.num_workers : null
 
   command {
     script_location = (


### PR DESCRIPTION
@aaronsteers - Hey AJ, I get an issue with MLOps now which I think is to do with Python Shell jobs in Glue. I don't think worker type and number of works is relevant here so I included the "with_spark" flag. This looks to have fixed it.